### PR TITLE
fix experiments plugin

### DIFF
--- a/src/plugins/experiments/hideBugReport.css
+++ b/src/plugins/experiments/hideBugReport.css
@@ -1,3 +1,0 @@
-#staff-help-popout-staff-help-bug-reporter {
-    display: none;
-}

--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -26,8 +26,6 @@ import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { Forms, React } from "@webpack/common";
 
-import hideBugReport from "./hideBugReport.css?managed";
-
 const KbdStyles = findByPropsLazy("key", "combo");
 
 const settings = definePluginSettings({
@@ -47,7 +45,8 @@ export default definePlugin({
         Devs.Ven,
         Devs.Nickyux,
         Devs.BanTheNons,
-        Devs.Nuckyz
+        Devs.Nuckyz,
+        Devs.Airbus
     ],
 
     settings,
@@ -65,13 +64,6 @@ export default definePlugin({
             replacement: {
                 match: /!(\i)&&"CONNECTION_OPEN".+?;/g,
                 replace: "$1=!0;"
-            }
-        },
-        {
-            find: 'H1,title:"Experiments"',
-            replacement: {
-                match: 'title:"Experiments",children:[',
-                replace: "$&$self.WarningCard(),"
             }
         },
         // change top right chat toolbar button from the help one to the dev one
@@ -94,9 +86,6 @@ export default definePlugin({
         }
     ],
 
-    start: () => enableStyle(hideBugReport),
-    stop: () => disableStyle(hideBugReport),
-
     settingsAboutComponent: () => {
         const isMacOS = navigator.platform.includes("Mac");
         const modKey = isMacOS ? "cmd" : "ctrl";
@@ -115,24 +104,4 @@ export default definePlugin({
             </React.Fragment>
         );
     },
-
-    WarningCard: ErrorBoundary.wrap(() => (
-        <ErrorCard id="vc-experiments-warning-card" className={Margins.bottom16}>
-            <Forms.FormTitle tag="h2">Hold on!!</Forms.FormTitle>
-
-            <Forms.FormText>
-                Experiments are unreleased Discord features. They might not work, or even break your client or get your account disabled.
-            </Forms.FormText>
-
-            <Forms.FormText className={Margins.top8}>
-                Only use experiments if you know what you're doing. Vencord is not responsible for any damage caused by enabling experiments.
-
-                If you don't know what an experiment does, ignore it. Do not ask us what experiments do either, we probably don't know.
-            </Forms.FormText>
-
-            <Forms.FormText className={Margins.top8}>
-                No, you cannot use server-side features like checking the "Send to Client" box.
-            </Forms.FormText>
-        </ErrorCard>
-    ), { noop: true })
 });

--- a/src/plugins/experiments/index.tsx
+++ b/src/plugins/experiments/index.tsx
@@ -17,11 +17,7 @@
 */
 
 import { definePluginSettings } from "@api/Settings";
-import { disableStyle, enableStyle } from "@api/Styles";
-import ErrorBoundary from "@components/ErrorBoundary";
-import { ErrorCard } from "@components/ErrorCard";
 import { Devs } from "@utils/constants";
-import { Margins } from "@utils/margins";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
 import { Forms, React } from "@webpack/common";


### PR DESCRIPTION
1. Get rid of unnecessarily large experiments tab warning banner
2. Show Discord staff bug report modal