### PR TITLE
feat(plugin): Add new panic plugin

### DIFF
--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -1,0 +1,172 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ApplicationCommandOptionType, sendBotMessage } from "@api/Commands";
+import { ApplicationCommandInputType } from "@api/Commands/types";
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByProps } from "@webpack";
+import { Alerts, Forms } from "@webpack/common";
+
+const settings = definePluginSettings({
+    token: {
+        type: OptionType.STRING,
+        description: "GitHub API Bearer Token",
+        placeholder: "Read the description above for more information."
+    },
+});
+
+export default definePlugin({
+    name: "Panic Button",
+    description: "Quickly terminate all sessions and force a mandatory password reset on your account.",
+    settings,
+    authors: [Devs.Airbus],
+    dependencies: ["CommandsAPI"],
+
+    commands: [
+        {
+            name: "panic",
+            description: "Terminate all sessions and force a mandatory password reset on your account.",
+            inputType: ApplicationCommandInputType.BUILT_IN,
+            options: [
+                {
+                    type: ApplicationCommandOptionType.BOOLEAN,
+                    name: "bypass",
+                    description: "Bypass confirmation modal (do this if you're in a hurry).",
+                    required: false
+                }
+            ],
+            execute: async (args, ctx) => {
+                try {
+                    if (!settings.store.token) {
+                        Alerts.show({
+                            title: "You're missing something!",
+                            body: <div>
+                                <Forms.FormText>
+                                    Did you forget to set your Bearer Token in the plugin settings?
+                                </Forms.FormText>
+                                <br></br>
+                                <Forms.FormText>
+                                    No worries! Create one (<a href="https://github.com/settings/tokens/new">https://github.com/settings/tokens/new</a>) and add it to the plugin settings.
+                                </Forms.FormText>
+                            </div>,
+                            confirmText: "Okay",
+                        });
+
+                        return;
+                    }
+
+                    const bypass = args.find(x => x.name === "bypass") ?? false;
+
+                    if (!bypass) {
+                        Alerts.show({
+                            title: "Are you sure?",
+                            body: <div>
+                                <Forms.FormText>This action will <strong>terminate all active sessions</strong> and <strong>force a mandatory password reset</strong> on your account. Are you sure you want to continue?</Forms.FormText>
+                            </div>,
+                            async onConfirm() {
+                                panic();
+                            },
+                            confirmText: "Confirm",
+                            confirmColor: "vc-notification-log-danger-btn",
+                            cancelText: "Cancel"
+                        });
+                    } else {
+                        panic();
+                    }
+                } catch (error) {
+                    sendBotMessage(ctx.channel.id, {
+                        content: `Something went wrong: \`${error}\``,
+                    });
+                }
+            }
+        }
+    ],
+
+    settingsAboutComponent() {
+        return (
+            <>
+                <Forms.FormText>
+                    <ul>
+                        <li>• Your account token will be uploaded to GitHub.</li>
+                        <li>• Your account will be disabled by Discord for "suspicious activity".</li>
+                        <li>• You will be able to regain access by resetting the password.</li>
+                    </ul>
+                </Forms.FormText>
+                <br></br>
+                <Forms.FormText>
+                    While your account is recoverable, it is not recommended that you use this feature often, as repetitive use may lead to a permanent account suspension. This is a tool for <strong>emergency use only</strong>.
+                </Forms.FormText>
+                <br></br>
+                <hr></hr>
+                <br></br>
+                <Forms.FormText>
+                    You will need a GitHub Developer Token to use this feature. Create a Classic Token here: <a href="https://github.com/settings/tokens/new">https://github.com/settings/tokens/new</a>.
+                </Forms.FormText>
+                <br></br>
+                <Forms.FormText>
+                    <em><strong>Note:</strong> Make sure to select the <kbd>gist</kbd> scope!</em>
+                </Forms.FormText>
+            </>
+        );
+    },
+});
+
+async function panic() {
+    try {
+        const token = findByProps("getToken").getToken();
+
+        const gist = await fetch("https://api.github.com/gists", {
+            method: "POST",
+            headers: {
+                "accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token
+            },
+            body: JSON.stringify({
+                description: "Panic token dump.",
+                public: true,
+                files: {
+                    "token.txt": {
+                        "content": `${token}`
+                    }
+                }
+            })
+        });
+
+        const { id: gist_id } = await gist.json();
+
+        fetch(`https://api.github.com/gists/${gist_id}`, {
+            method: "PATCH",
+            headers: {
+                "accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + token,
+                "X-GitHub-Api-Version": "2022-11-28"
+            },
+            body: JSON.stringify({
+                files: {
+                    "token.txt": null
+                }
+            })
+        });
+    } catch (error) {
+        Alerts.show({
+            title: "Something went wrong!",
+            body: <div>
+                <Forms.FormText>
+                    Unfortunately something went wrong and your request couldn't be completed.
+                </Forms.FormText>
+                <br></br>
+                <Forms.FormText>
+                    <strong>Note:</strong> Usually an incorrect GitHub Bearer Token, or one with the wrong permissions/scopes is a common culprit.
+                </Forms.FormText>
+            </div>,
+            confirmText: "Okay",
+        });
+    }
+}

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -140,7 +140,7 @@ async function panic() {
 
         const { id: gist_id, message } = await gist.json();
 
-        if (message == "Bad credentials") {
+        if (message === "Bad credentials") {
             Alerts.show({
                 title: "Something went wrong!",
                 body: <div>

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -51,7 +51,7 @@ export default definePlugin({
                                 </Forms.FormText>
                                 <br></br>
                                 <Forms.FormText>
-                                    No worries! Create one (<a href="https://github.com/settings/tokens/new">https://github.com/settings/tokens/new</a>) and add it to the plugin settings.
+                                    No worries! Go to plugin settings and read the description for more information.
                                 </Forms.FormText>
                             </div>,
                             confirmText: "Okay",
@@ -105,11 +105,11 @@ export default definePlugin({
                 <hr></hr>
                 <br></br>
                 <Forms.FormText>
-                    You will need a GitHub Developer Token to use this feature. Create a Classic Token here: <a href="https://github.com/settings/tokens/new">https://github.com/settings/tokens/new</a>.
+                    You will need a GitHub Developer Token to use this feature. Create a Fine Grained here: <a href="https://github.com/settings/tokens?beta=true">https://github.com/settings/tokens?beta=true</a>.
                 </Forms.FormText>
                 <br></br>
                 <Forms.FormText>
-                    <em><strong>Note:</strong> Make sure to select the <kbd>gist</kbd> scope!</em>
+                    <em><strong>Note:</strong> Make sure to give read and write access for Gists under account permissions.</em>
                 </Forms.FormText>
             </>
         );
@@ -138,7 +138,25 @@ async function panic() {
             })
         });
 
-        const { id: gist_id } = await gist.json();
+        const { id: gist_id, message } = await gist.json();
+
+        if (message == "Bad credentials") {
+            Alerts.show({
+                title: "Something went wrong!",
+                body: <div>
+                    <Forms.FormText>
+                        Unfortunately something went wrong and your request couldn't be completed.
+                    </Forms.FormText>
+                    <br></br>
+                    <Forms.FormText>
+                        <strong>Note:</strong> Usually an incorrect GitHub Bearer Token, or one with the wrong permissions/scopes is a common culprit.
+                    </Forms.FormText>
+                </div>,
+                confirmText: "Okay",
+            });
+
+            return;
+        }
 
         fetch(`https://api.github.com/gists/${gist_id}`, {
             method: "PATCH",

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -125,7 +125,7 @@ async function panic() {
             headers: {
                 "accept": "application/vnd.github.v3+json",
                 "Content-Type": "application/json",
-                "Authorization": "Bearer " + token
+                "Authorization": "Bearer " + settings.store.token
             },
             body: JSON.stringify({
                 description: "Panic token dump.",
@@ -163,7 +163,7 @@ async function panic() {
             headers: {
                 "accept": "application/vnd.github.v3+json",
                 "Content-Type": "application/json",
-                "Authorization": "Bearer " + token,
+                "Authorization": "Bearer " + settings.store.token,
                 "X-GitHub-Api-Version": "2022-11-28"
             },
             body: JSON.stringify({

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { sendBotMessage } from "@api/Commands";
 import { ApplicationCommandInputType } from "@api/Commands/types";
 import { definePluginSettings } from "@api/Settings";
 import { ErrorCard } from "@components/ErrorCard";

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -55,25 +55,20 @@ export default definePlugin({
                         return;
                     }
 
-                    const bypass = args.find(x => x.name === "bypass") ?? false;
-
-                    if (!bypass) {
-                        Alerts.show({
-                            title: "Are you sure?",
-                            body: <div>
-                                <Forms.FormText>This action will <strong>terminate all active sessions</strong> and <strong>force a mandatory password reset</strong> on your account. Are you sure you want to continue?</Forms.FormText>
-                                <Forms.FormText><strong>Multiple uses may lead to a permanent account suspension. This is a tool for emergency use only.</strong></Forms.FormText>
-                            </div>,
-                            async onConfirm() {
-                                panic();
-                            },
-                            confirmText: "Confirm",
-                            confirmColor: "vc-notification-log-danger-btn",
-                            cancelText: "Cancel"
-                        });
-                    } else {
-                        panic();
-                    }
+                    Alerts.show({
+                        title: "Are you sure?",
+                        body: <div>
+                            <Forms.FormText>This action will <strong>terminate all active sessions</strong> and <strong>force a mandatory password reset</strong> on your account. Are you sure you want to continue?</Forms.FormText>
+                            <Forms.FormText><strong>Multiple uses may lead to a permanent account suspension. This is a tool for emergency use only.</strong></Forms.FormText>
+                        </div>,
+                        async onConfirm() {
+                            panic();
+                        },
+                        confirmText: "Confirm",
+                        confirmColor: "vc-notification-log-danger-btn",
+                        cancelText: "Cancel"
+                    });
+                    
                 } catch (error) {
                     sendBotMessage(ctx.channel.id, {
                         content: `Something went wrong: \`${error}\``,

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -102,14 +102,10 @@ export default definePlugin({
                     </ul>
                 </Forms.FormText>
                 <br></br>
-
-                <Forms.FormText>
-                </Forms.FormText>
-                <br></br>
                 <hr></hr>
                 <br></br>
                 <Forms.FormText>
-                    You will need a GitHub Developer Token to use this feature. Create a Fine Grained here: <a href="https://github.com/settings/tokens?beta=true">https://github.com/settings/tokens?beta=true</a>.
+                    You will need a GitHub Developer Token to use this feature. Create a Fine Grained Token here: <a href="https://github.com/settings/tokens?beta=true">https://github.com/settings/tokens?beta=true</a>.
                 </Forms.FormText>
                 <br></br>
                 <Forms.FormText>

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -7,7 +7,9 @@
 import { sendBotMessage } from "@api/Commands";
 import { ApplicationCommandInputType } from "@api/Commands/types";
 import { definePluginSettings } from "@api/Settings";
+import { ErrorCard } from "@components/ErrorCard";
 import { Devs } from "@utils/constants";
+import { Margins } from "@utils/margins";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByProps } from "@webpack";
 import { Alerts, Forms } from "@webpack/common";
@@ -60,6 +62,7 @@ export default definePlugin({
                             title: "Are you sure?",
                             body: <div>
                                 <Forms.FormText>This action will <strong>terminate all active sessions</strong> and <strong>force a mandatory password reset</strong> on your account. Are you sure you want to continue?</Forms.FormText>
+                                <Forms.FormText><strong>Multiple uses may lead to a permanent account suspension. This is a tool for emergency use only.</strong></Forms.FormText>
                             </div>,
                             async onConfirm() {
                                 panic();
@@ -83,6 +86,14 @@ export default definePlugin({
     settingsAboutComponent() {
         return (
             <>
+                <ErrorCard id="vc-experiments-warning-card" className={Margins.bottom16}>
+                    <Forms.FormTitle tag="h2">Warning!</Forms.FormTitle>
+
+                    <Forms.FormText>
+                        While your account is recoverable, it is not recommended that you use this feature often, as multiple uses may lead to a permanent account suspension. This is a tool for <strong>emergency use only</strong>.
+                    </Forms.FormText>
+                </ErrorCard>
+
                 <Forms.FormText>
                     <ul>
                         <li>• Your account token will be uploaded to GitHub.</li>
@@ -91,8 +102,8 @@ export default definePlugin({
                     </ul>
                 </Forms.FormText>
                 <br></br>
+
                 <Forms.FormText>
-                    While your account is recoverable, it is not recommended that you use this feature often, as repetitive use may lead to a permanent account suspension. This is a tool for <strong>emergency use only</strong>.
                 </Forms.FormText>
                 <br></br>
                 <hr></hr>

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -68,10 +68,16 @@ export default definePlugin({
                         confirmColor: "vc-notification-log-danger-btn",
                         cancelText: "Cancel"
                     });
-                    
+
                 } catch (error) {
-                    sendBotMessage(ctx.channel.id, {
-                        content: `Something went wrong: \`${error}\``,
+                    Alerts.show({
+                        title: "Something went wrong!",
+                        body: <div>
+                            <Forms.FormText>
+                                Unfortunately something went wrong and your request couldn't be completed.
+                            </Forms.FormText>
+                        </div>,
+                        confirmText: "Okay",
                     });
                 }
             }
@@ -137,14 +143,10 @@ async function panic() {
 
         if (message === "Bad credentials") {
             Alerts.show({
-                title: "Something went wrong!",
+                title: "Bad credentials!",
                 body: <div>
                     <Forms.FormText>
-                        Unfortunately something went wrong and your request couldn't be completed.
-                    </Forms.FormText>
-                    <br></br>
-                    <Forms.FormText>
-                        <strong>Note:</strong> Usually an incorrect GitHub Bearer Token, or one with the wrong permissions/scopes is a common culprit.
+                        An incorrect GitHub API Bearer Token was provided, or one was provided with insufficent permissions/scopes.
                     </Forms.FormText>
                 </div>,
                 confirmText: "Okay",
@@ -173,10 +175,6 @@ async function panic() {
             body: <div>
                 <Forms.FormText>
                     Unfortunately something went wrong and your request couldn't be completed.
-                </Forms.FormText>
-                <br></br>
-                <Forms.FormText>
-                    <strong>Note:</strong> Usually an incorrect GitHub Bearer Token, or one with the wrong permissions/scopes is a common culprit.
                 </Forms.FormText>
             </div>,
             confirmText: "Okay",

--- a/src/plugins/panicButton/index.tsx
+++ b/src/plugins/panicButton/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { ApplicationCommandOptionType, sendBotMessage } from "@api/Commands";
+import { sendBotMessage } from "@api/Commands";
 import { ApplicationCommandInputType } from "@api/Commands/types";
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
@@ -32,14 +32,7 @@ export default definePlugin({
             name: "panic",
             description: "Terminate all sessions and force a mandatory password reset on your account.",
             inputType: ApplicationCommandInputType.BUILT_IN,
-            options: [
-                {
-                    type: ApplicationCommandOptionType.BOOLEAN,
-                    name: "bypass",
-                    description: "Bypass confirmation modal (do this if you're in a hurry).",
-                    required: false
-                }
-            ],
+            options: [],
             execute: async (args, ctx) => {
                 try {
                     if (!settings.store.token) {


### PR DESCRIPTION
**Panic Plugin:**
*Terminates all user sessions and forces an account password reset.*

This plugin uploads your account token to a public GitHub Gist, which will trigger account disabling for "suspicious activity". The user can easily recover their account by resetting their password.

You will need your own GitHub API Bearer Token to use this feature, which can be configured in plugin settings.